### PR TITLE
Handle interrupts

### DIFF
--- a/src/booter/game.c
+++ b/src/booter/game.c
@@ -1,16 +1,22 @@
 #include "video.h"
+#include "interrupts.h"
+#include "timer.h"
+#include "keyboard.h"
 
 /* This is the entry-point for the game! */
 void c_start(void) {
-    /* TODO:  You will need to initialize various subsystems here.  This
+    // TODO(agf): Remove this block comment
+    /*        You will need to initialize various subsystems here.  This
      *        would include the interrupt handling mechanism, and the various
      *        systems that use interrupts.  Once this is done, you can call
      *        enable_interrupts() to start interrupt handling, and go on to
      *        do whatever else you decide to do!
      */
-
     init_video();
+    init_interrupts();
+    init_timer();
+    init_keyboard();
+    enable_interrupts();
     /* Loop forever, so that we don't fall back into the bootloader code. */
     while (1) {}
 }
-

--- a/src/booter/handlers.S
+++ b/src/booter/handlers.S
@@ -1,4 +1,5 @@
-# TODO:  Put IRQ handlers in this file.  The handlers can do whatever you
+# TODO(agf): Remove this comment block
+#        Put IRQ handlers in this file.  The handlers can do whatever you
 #        want, but the recommendation is to keep them very simple; for
 #        example, call a C function that handles the interrupt and then
 #        returns.
@@ -29,3 +30,43 @@
 #
 #                popa    # Restore all registers
 #                iret    # Go back to interrupted code
+
+.globl handle_timer_interrupt
+.globl handle_keyboard_interrupt
+
+.align 4
+.globl irq_timer_handler
+irq_timer_handler:
+        pusha   # Save registers from the interrupted code!
+        cld     # If calling C code, clear direction flag
+
+        call handle_timer_interrupt
+
+        # Acknowledge the interrupt so that the PIC will send more
+        # interrupts!  We do this by sending 0x20 to port 0x20.
+        # See http://wiki.osdev.org/8259_PIC#End_of_Interrupt for
+        # details.
+        mov     $0x20, %al
+        out     %al, $0x20
+
+        popa    # Restore all registers
+        iret    # Go back to interrupted code
+
+
+.align 4
+.globl irq_keyboard_handler
+irq_keyboard_handler:
+        pusha   # Save registers from the interrupted code!
+        cld     # If calling C code, clear direction flag
+
+        call handle_keyboard_interrupt
+
+        # Acknowledge the interrupt so that the PIC will send more
+        # interrupts!  We do this by sending 0x20 to port 0x20.
+        # See http://wiki.osdev.org/8259_PIC#End_of_Interrupt for
+        # details.
+        mov     $0x20, %al
+        out     %al, $0x20
+
+        popa    # Restore all registers
+        iret    # Go back to interrupted code

--- a/src/booter/handlers.h
+++ b/src/booter/handlers.h
@@ -1,5 +1,17 @@
+#ifndef HANDLERS_H
+#define HANDLERS_H
+
+
+// TODO(agf): Remove this comment block
 /* Declare the entry-points to the interrupt handler assembly-code fragments,
  * so that the C compiler will be happy.
  *
  * You will need lines like these:  void *(irqN_handler)(void)
  */
+
+void *(irq_timer_handler)(void);
+
+void *(irq_keyboard_handler)(void);
+
+
+#endif /* HANDLERS_H */

--- a/src/booter/keyboard.c
+++ b/src/booter/keyboard.c
@@ -1,4 +1,7 @@
 #include "ports.h"
+#include "interrupts.h"
+#include "handlers.h"
+#include "video.h"
 
 /* This is the IO port of the PS/2 controller, where the keyboard's scan
  * codes are made available.  Scan codes can be read as follows:
@@ -36,12 +39,29 @@
  *        so that nothing gets mangled...
  */
 
+volatile static int num_presses;
+
+
+// If the "A" key was pressed, then advance a "KeyboardSaysHi" message
+// horizontally across the screen
+void handle_keyboard_interrupt(void) {
+    unsigned char scan_code = inb(KEYBOARD_PORT);
+    if (scan_code == 0x1E) {
+        // The "A" key was pressed
+        char * message =         "KeyboardSaysHi";
+        char * blank_messagage = "              ";
+        int prev_offset = (num_presses % 80) + 80 * 10;
+        write_string(GREEN, blank_messagage, prev_offset);
+        num_presses++;
+        int offset = (num_presses % 80) + 80 * 10;
+        write_string(GREEN, message, offset);
+    }
+}
 
 void init_keyboard(void) {
     /* TODO:  Initialize any state required by the keyboard handler. */
+    num_presses = 0;
 
-    /* TODO:  You might want to install your keyboard interrupt handler
-     *        here as well.
-     */
+    install_interrupt_handler(KEYBOARD_INTERRUPT, irq_keyboard_handler);
 }
 

--- a/src/booter/keyboard.h
+++ b/src/booter/keyboard.h
@@ -1,6 +1,8 @@
 #ifndef KEYBOARD_H
 #define KEYBOARD_H
 
+void handle_keyboard_interrupt(void);
+
 void init_keyboard(void);
 
 #endif /* KEYBOARD_H */

--- a/src/booter/timer.c
+++ b/src/booter/timer.c
@@ -1,5 +1,8 @@
 #include "timer.h"
 #include "ports.h"
+#include "interrupts.h"
+#include "handlers.h"
+#include "video.h"
 
 /*============================================================================
  * PROGRAMMABLE INTERVAL TIMER
@@ -46,6 +49,19 @@
  *        compiler knows they can be changed by exceptional control flow.
  */
 
+volatile static int num_ticks;
+
+
+// Advance a "TimerSaysHi" message vertically across the screen
+void handle_timer_interrupt(void) {
+    char * message =       "TimerSaysHi";
+    char * blank_message = "           ";
+    int prev_offset = 40 + (num_ticks % 25) * 80;
+    write_string(GREEN, blank_message, prev_offset);
+    num_ticks++;
+    int offset = 40 + (num_ticks % 25) * 80;
+    write_string(GREEN, message, offset);
+}
 
 void init_timer(void) {
 
@@ -62,8 +78,7 @@ void init_timer(void) {
     outb(PIT_CHAN0_DATA, 0x2e);
 
     /* TODO:  Initialize other timer state here. */
+    num_ticks = 0;
 
-    /* TODO:  You might want to install your timer interrupt handler
-     *        here as well.
-     */
+    install_interrupt_handler(TIMER_INTERRUPT, irq_timer_handler);
 }

--- a/src/booter/timer.h
+++ b/src/booter/timer.h
@@ -2,6 +2,8 @@
 #define TIMER_H
 
 
+void handle_timer_interrupt(void);
+
 void init_timer(void);
 
 

--- a/src/booter/video.c
+++ b/src/booter/video.c
@@ -55,8 +55,5 @@ void init_video(void) {
      *        as clearing the screen, initializing static variable state, etc.
      */
     paint_display(WHITE_ON_BLUE);
-    write_string(BLUE, "Laser", 0);
-    write_string(GREEN, "Phaser", 80);
-    write_string(WHITE_ON_BLUE, "Star", 24 * 80);
+    write_string(WHITE_ON_BLUE, "Hi", 24 * 80);
 }
-

--- a/src/booter/video.h
+++ b/src/booter/video.h
@@ -25,6 +25,9 @@
 /* Colors with non-black backgrounds */
 #define WHITE_ON_BLUE 0x1f
 
+void write_string(int color, const char *string, int offset);
+
+void paint_display(int color);
 
 void init_video(void);
 


### PR DESCRIPTION
Initialize and load the Interrupt Descriptor Table. Install interrupt
handlers for timer and keyboard. These handlers call the C functions
handle_time_interrupt() and handle_keyboard_interrupt().

Main program uses timer interrupt to display a "TimerSaysHi" message
scrolling vertically across the screen, and uses keyboard interrupt with
to advance a "KeyboardSaysHi" message horizontally across the screen
when the "A" key is pressed.
